### PR TITLE
Add Transition and MITUMERUNDESU decks

### DIFF
--- a/Slides/Package.swift
+++ b/Slides/Package.swift
@@ -32,6 +32,14 @@ let package = Package(
       targets: ["SelfIntroduce"]
     ),
     .library(
+      name: "SwiftUITransition",
+      targets: ["SwiftUITransition"]
+    ),
+    .library(
+      name: "MitumerundesuSpatialPhoto",
+      targets: ["MitumerundesuSpatialPhoto"]
+    ),
+    .library(
       name: "visionOSMeetupVol10",
       targets: ["visionOSMeetupVol10"]
     ),
@@ -54,6 +62,8 @@ let package = Package(
         "AboutSkip",
         "Potatotips0527",
         "visionOSMeetupVol10",
+        "SwiftUITransition",
+        "MitumerundesuSpatialPhoto",
       ]
     ),
     .target(
@@ -87,6 +97,24 @@ let package = Package(
       name: "SelfIntroduce",
       dependencies: [
         "Common",
+        .product(name: "SlideKit", package: "SlideKit"),
+      ]
+    ),
+    .target(
+      name: "SwiftUITransition",
+      dependencies: [
+        "Exhivision",
+        "Common",
+        "SelfIntroduce",
+        .product(name: "SlideKit", package: "SlideKit"),
+      ]
+    ),
+    .target(
+      name: "MitumerundesuSpatialPhoto",
+      dependencies: [
+        "Exhivision",
+        "Common",
+        "SelfIntroduce",
         .product(name: "SlideKit", package: "SlideKit"),
       ]
     ),

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -3,6 +3,8 @@ import Common
 import Potatotips0527
 import SlideKit
 import SwiftUI
+import SwiftUITransition
+import MitumerundesuSpatialPhoto
 import visionOSMeetupVol10
 
 @Observable @MainActor
@@ -11,6 +13,8 @@ public final class PresentationStore {
   var aboutConiguration: AboutSkipSlideConfiguration = .init()
   var potatotipsConfiguration: Potatotips0527SlideConfiguration = .init()
   var visionProMeetupVol10 = VisionOSMeetUpVol10Configuration()
+  var swiftuiTransitionConfiguration = SwiftUITransitionSlideConfiguration()
+  var mitumerundesuConfiguration = MitumerundesuSpatialPhotoSlideConfiguration()
   public var currentSlideConfiguration: (any SlideConfigurationInterface)?
 }
 
@@ -51,6 +55,30 @@ public struct AppView: View {
         } label: {
           HStack {
             Text(store.potatotipsConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
+
+        Button {
+          store.currentSlideConfiguration = store.swiftuiTransitionConfiguration
+          openWindows()
+        } label: {
+          HStack {
+            Text(store.swiftuiTransitionConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
+
+        Button {
+          store.currentSlideConfiguration = store.mitumerundesuConfiguration
+          openWindows()
+        } label: {
+          HStack {
+            Text(store.mitumerundesuConfiguration.title)
               .frame(maxWidth: .infinity, alignment: .leading)
 
             Image(systemName: "chevron.forward")

--- a/Slides/Sources/MitumerundesuSpatialPhoto/MitumerundesuSpatialPhotoConfiguration.swift
+++ b/Slides/Sources/MitumerundesuSpatialPhoto/MitumerundesuSpatialPhotoConfiguration.swift
@@ -1,0 +1,19 @@
+import Common
+import Exhivision
+import SelfIntroduce
+import SlideKit
+import SwiftUI
+
+public struct MitumerundesuSpatialPhotoSlideConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "mitumerundesu-spatial-photo"
+  public var title: String = "MITUMERUNDESUで撮った写真を空間写真へ"
+  public let size = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroduce()
+    AboutExhivision()
+  }
+  public let theme: any SlideTheme = .default
+}

--- a/Slides/Sources/MitumerundesuSpatialPhoto/Slides/01_Title.swift
+++ b/Slides/Sources/MitumerundesuSpatialPhoto/Slides/01_Title.swift
@@ -1,0 +1,20 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    VStack {
+      Text("MITUMERUNDESUで撮った写真を空間写真へ")
+        .font(.system(size: 108))
+    }
+  }
+
+  var shouldHideIndex: Bool { true }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/SwiftUITransition/Slides/01_Title.swift
+++ b/Slides/Sources/SwiftUITransition/Slides/01_Title.swift
@@ -1,0 +1,20 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    VStack {
+      Text("SwiftUIのTransitionの世界")
+        .font(.system(size: 108))
+    }
+  }
+
+  var shouldHideIndex: Bool { true }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/SwiftUITransition/SwiftUITransitionConfiguration.swift
+++ b/Slides/Sources/SwiftUITransition/SwiftUITransitionConfiguration.swift
@@ -1,0 +1,19 @@
+import Common
+import Exhivision
+import SelfIntroduce
+import SlideKit
+import SwiftUI
+
+public struct SwiftUITransitionSlideConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "swiftui-transition"
+  public var title: String = "SwiftUIのTransitionの世界"
+  public let size = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroduce()
+    AboutExhivision()
+  }
+  public let theme: any SlideTheme = .default
+}


### PR DESCRIPTION
## Summary
- add `SwiftUITransition` deck
- add `MitumerundesuSpatialPhoto` deck
- hook new decks into the app and package
- include Exhivision slide in both new decks

## Testing
- `swift build --target App` *(fails: unable to access https://github.com/mtj0928/SlideKit.git)*

------
https://chatgpt.com/codex/tasks/task_e_68435e87c73883218e97e5c94dd27264