### PR TITLE
Add Transition and MITUMERUNDESU decks

### DIFF
--- a/Slides/Package.swift
+++ b/Slides/Package.swift
@@ -16,12 +16,16 @@ let package = Package(
       targets: ["App"]
     ),
     .library(
+      name: "Common",
+      targets: ["Common"]
+    ),
+    .library(
       name: "Exhivision",
       targets: ["Exhivision"]
     ),
     .library(
-      name: "Common",
-      targets: ["Common"]
+      name: "MitumerundesuSpatialPhoto",
+      targets: ["MitumerundesuSpatialPhoto"]
     ),
     .library(
       name: "Potatotips0527",
@@ -30,6 +34,10 @@ let package = Package(
     .library(
       name: "SelfIntroduce",
       targets: ["SelfIntroduce"]
+    ),
+    .library(
+      name: "SwiftUITransition",
+      targets: ["SwiftUITransition"]
     ),
     .library(
       name: "visionOSMeetupVol10",
@@ -52,8 +60,16 @@ let package = Package(
       name: "App",
       dependencies: [
         "AboutSkip",
+        "MitumerundesuSpatialPhoto",
         "Potatotips0527",
+        "SwiftUITransition",
         "visionOSMeetupVol10",
+      ]
+    ),
+    .target(
+      name: "Common",
+      dependencies: [
+        .product(name: "SlideKit", package: "SlideKit")
       ]
     ),
     .target(
@@ -66,16 +82,19 @@ let package = Package(
       ]
     ),
     .target(
-      name: "Common",
+      name: "MitumerundesuSpatialPhoto",
       dependencies: [
-        .product(name: "SlideKit", package: "SlideKit")
+        "Common",
+        "Exhivision",
+        "SelfIntroduce",
+        .product(name: "SlideKit", package: "SlideKit"),
       ]
     ),
     .target(
       name: "Potatotips0527",
       dependencies: [
-        "Exhivision",
         "Common",
+        "Exhivision",
         "SelfIntroduce",
         .product(name: "SlideKit", package: "SlideKit"),
       ],
@@ -91,10 +110,19 @@ let package = Package(
       ]
     ),
     .target(
+      name: "SwiftUITransition",
+      dependencies: [
+        "Common",
+        "Exhivision",
+        "SelfIntroduce",
+        .product(name: "SlideKit", package: "SlideKit"),
+      ]
+    ),
+    .target(
       name: "visionOSMeetupVol10",
       dependencies: [
-        "Exhivision",
         "Common",
+        "Exhivision",
         "SelfIntroduce",
         .product(name: "SlideKit", package: "SlideKit"),
       ]

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -3,6 +3,8 @@ import Common
 import Potatotips0527
 import SlideKit
 import SwiftUI
+import SwiftUITransition
+import MitumerundesuSpatialPhoto
 import visionOSMeetupVol10
 
 @Observable @MainActor
@@ -11,6 +13,8 @@ public final class PresentationStore {
   var aboutConiguration: AboutSkipSlideConfiguration = .init()
   var potatotipsConfiguration: Potatotips0527SlideConfiguration = .init()
   var visionProMeetupVol10 = VisionOSMeetUpVol10Configuration()
+  var swiftuiTransitionConfiguration = SwiftUITransitionSlideConfiguration()
+  var mitumerundesuConfiguration = MitumerundesuSpatialPhotoSlideConfiguration()
   public var currentSlideConfiguration: (any SlideConfigurationInterface)?
 }
 
@@ -51,6 +55,30 @@ public struct AppView: View {
         } label: {
           HStack {
             Text(store.potatotipsConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
+
+        Button {
+          store.currentSlideConfiguration = store.swiftuiTransitionConfiguration
+          openWindows()
+        } label: {
+          HStack {
+            Text(store.swiftuiTransitionConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
+
+        Button {
+          store.currentSlideConfiguration = store.mitumerundesuConfiguration
+          openWindows()
+        } label: {
+          HStack {
+            Text(store.mitumerundesuConfiguration.title)
               .frame(maxWidth: .infinity, alignment: .leading)
 
             Image(systemName: "chevron.forward")

--- a/Slides/Sources/MitumerundesuSpatialPhoto/MitumerundesuSpatialPhotoConfiguration.swift
+++ b/Slides/Sources/MitumerundesuSpatialPhoto/MitumerundesuSpatialPhotoConfiguration.swift
@@ -1,0 +1,19 @@
+import Common
+import Exhivision
+import SelfIntroduce
+import SlideKit
+import SwiftUI
+
+public struct MitumerundesuSpatialPhotoSlideConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "mitumerundesu-spatial-photo"
+  public var title: String = "MITUMERUNDESUで撮った写真を空間写真へ"
+  public let size = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroduce()
+    AboutExhivision()
+  }
+  public let theme: any SlideTheme = .default
+}

--- a/Slides/Sources/MitumerundesuSpatialPhoto/Slides/01_Title.swift
+++ b/Slides/Sources/MitumerundesuSpatialPhoto/Slides/01_Title.swift
@@ -1,0 +1,20 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    VStack {
+      Text("MITUMERUNDESUで撮った写真を空間写真へ")
+        .font(.system(size: 108))
+    }
+  }
+
+  var shouldHideIndex: Bool { true }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/SwiftUITransition/Slides/01_Title.swift
+++ b/Slides/Sources/SwiftUITransition/Slides/01_Title.swift
@@ -1,0 +1,20 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    VStack {
+      Text("SwiftUIのTransitionの世界")
+        .font(.system(size: 108))
+    }
+  }
+
+  var shouldHideIndex: Bool { true }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/SwiftUITransition/SwiftUITransitionConfiguration.swift
+++ b/Slides/Sources/SwiftUITransition/SwiftUITransitionConfiguration.swift
@@ -1,0 +1,19 @@
+import Common
+import Exhivision
+import SelfIntroduce
+import SlideKit
+import SwiftUI
+
+public struct SwiftUITransitionSlideConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "swiftui-transition"
+  public var title: String = "SwiftUIのTransitionの世界"
+  public let size = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroduce()
+    AboutExhivision()
+  }
+  public let theme: any SlideTheme = .default
+}


### PR DESCRIPTION
## Summary
- add `SwiftUITransition` deck
- add `MitumerundesuSpatialPhoto` deck
- hook new decks into the app and package
- include Exhivision slide in both new decks
- sort libraries and targets alphabetically in `Package.swift`

## Testing
- `swift build --target App` *(fails: unable to access https://github.com/mtj0928/SlideKit.git)*

------
https://chatgpt.com/codex/tasks/task_e_68435e87c73883218e97e5c94dd27264