### PR TITLE
Add iOSDC2025Interview presentation

### DIFF
--- a/Slides/Package.swift
+++ b/Slides/Package.swift
@@ -43,6 +43,10 @@ let package = Package(
       name: "visionOSMeetupVol10",
       targets: ["visionOSMeetupVol10"]
     ),
+    .library(
+      name: "iOSDC2025Interview",
+      targets: ["iOSDC2025Interview"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/mtj0928/SlideKit.git", from: "0.6.1"),
@@ -65,6 +69,7 @@ let package = Package(
         "Potatotips0527",
         "SwiftUITransition",
         "visionOSMeetupVol10",
+        "iOSDC2025Interview",
       ]
     ),
     .target(
@@ -126,6 +131,13 @@ let package = Package(
         "Common",
         "Exhivision",
         "SelfIntroduce",
+        .product(name: "SlideKit", package: "SlideKit"),
+      ]
+    ),
+    .target(
+      name: "iOSDC2025Interview",
+      dependencies: [
+        "Common",
         .product(name: "SlideKit", package: "SlideKit"),
       ]
     ),

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -6,6 +6,7 @@ import SlideKit
 import SwiftUI
 import SwiftUITransition
 import visionOSMeetupVol10
+import iOSDC2025Interview
 
 @Observable @MainActor
 public final class PresentationStore {
@@ -86,6 +87,18 @@ public struct AppView: View {
         } label: {
           HStack {
             Text(MitumerundesuSpatialPhotoSlideConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
+
+        Button {
+          store.currentSlideConfiguration = iOSDC2025InterviewSlideConfiguration()
+          openWindows()
+        } label: {
+          HStack {
+            Text(iOSDC2025InterviewSlideConfiguration.title)
               .frame(maxWidth: .infinity, alignment: .leading)
 
             Image(systemName: "chevron.forward")

--- a/Slides/Sources/iOSDC2025Interview/Slides/01_Title.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/01_Title.swift
@@ -1,0 +1,19 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    VStack {
+      Text("iOSDC2025 Interview")
+        .font(.system(size: 108))
+    }
+  }
+  var shouldHideIndex: Bool { true }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/02_SelfIntroduction.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/02_SelfIntroduction.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct SelfIntroductionSlide: View {
+  var body: some View {
+    Text("自己紹介")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    SelfIntroductionSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/03_WhyHost.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/03_WhyHost.swift
@@ -1,0 +1,17 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct WhyHostSlide: View {
+  var body: some View {
+    Text("なぜ○○.swiftを開催しようと思ったか")
+      .font(.system(size: 96))
+      .multilineTextAlignment(.center)
+  }
+}
+
+#Preview {
+  SlidePreview {
+    WhyHostSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/04_AfterHosting.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/04_AfterHosting.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct AfterHostingSlide: View {
+  var body: some View {
+    Text("開催してどうだったか")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    AfterHostingSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/05_MemorableEvent.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/05_MemorableEvent.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct MemorableEventSlide: View {
+  var body: some View {
+    Text("印象に残っている出来事は？")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    MemorableEventSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct RegionalFlavorSlide: View {
+  var body: some View {
+    Text("“地域らしさ” を出す工夫")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    RegionalFlavorSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/07_OperationDifficulty.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/07_OperationDifficulty.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct OperationDifficultySlide: View {
+  var body: some View {
+    Text("運営で苦労したこと")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    OperationDifficultySlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/08_NextEvent.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/08_NextEvent.swift
@@ -1,0 +1,17 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct NextEventSlide: View {
+  var body: some View {
+    Text("次回の開催について何か考えていることはあるか？")
+      .font(.system(size: 96))
+      .multilineTextAlignment(.center)
+  }
+}
+
+#Preview {
+  SlidePreview {
+    NextEventSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/09_OtherRegions.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/09_OtherRegions.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct OtherRegionsSlide: View {
+  var body: some View {
+    Text("他の地域だとどこにいきたい？")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    OtherRegionsSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/10_MessageForHosts.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/10_MessageForHosts.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct MessageForHostsSlide: View {
+  var body: some View {
+    Text("これから開催を考えている人に一言")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    MessageForHostsSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/Slides/11_AnythingElse.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/11_AnythingElse.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct AnythingElseSlide: View {
+  var body: some View {
+    Text("他に言いたいことあれば")
+      .font(.system(size: 96))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    AnythingElseSlide()
+  }
+}

--- a/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
+++ b/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
@@ -1,0 +1,25 @@
+import Common
+import SlideKit
+import SwiftUI
+
+public struct iOSDC2025InterviewSlideConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "iosdc2025-interview"
+  public static var title: String = "iOSDC2025 Interview"
+  public let size = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroductionSlide()
+    WhyHostSlide()
+    AfterHostingSlide()
+    MemorableEventSlide()
+    RegionalFlavorSlide()
+    OperationDifficultySlide()
+    NextEventSlide()
+    OtherRegionsSlide()
+    MessageForHostsSlide()
+    AnythingElseSlide()
+  }
+  public let theme: any SlideTheme = .default
+}


### PR DESCRIPTION
## Summary
- add new presentation `iOSDC2025Interview`
- include slides for interview topics
- hook up presentation in `AppView` and package manifest

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6867529a64e08321abcc4783c4908ecf