### PR TITLE
Add transition to interview slides

### DIFF
--- a/Slides/Sources/iOSDC2025Interview/Slides/02_SelfIntroduction.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/02_SelfIntroduction.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct SelfIntroductionSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("自己紹介")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/03_WhyHost.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/03_WhyHost.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct WhyHostSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("なぜ○○.swiftを開催しようと思ったか")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/04_AfterHosting.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/04_AfterHosting.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct AfterHostingSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("開催してどうだったか")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/05_MemorableEvent.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/05_MemorableEvent.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct MemorableEventSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("印象に残っている出来事は？")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
@@ -6,7 +6,7 @@ struct RegionalFlavorSlide: View {
   var transition: AnyTransition = .push(from: .trailing)
   
   var body: some View {
-    Text(""地域らしさ" を出す工夫")
+    Text("'地域らしさ' を出す工夫")
       .font(.system(size: 96))
   }
 }

--- a/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/06_RegionalFlavor.swift
@@ -3,8 +3,10 @@ import SwiftUI
 
 @Slide
 struct RegionalFlavorSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
-    Text("“地域らしさ” を出す工夫")
+    Text(""地域らしさ" を出す工夫")
       .font(.system(size: 96))
   }
 }

--- a/Slides/Sources/iOSDC2025Interview/Slides/07_OperationDifficulty.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/07_OperationDifficulty.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct OperationDifficultySlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("運営で苦労したこと")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/08_NextEvent.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/08_NextEvent.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct NextEventSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("次回の開催について何か考えていることはあるか？")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/09_OtherRegions.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/09_OtherRegions.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct OtherRegionsSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("他の地域だとどこにいきたい？")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/10_MessageForHosts.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/10_MessageForHosts.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct MessageForHostsSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("これから開催を考えている人に一言")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/Slides/11_AnythingElse.swift
+++ b/Slides/Sources/iOSDC2025Interview/Slides/11_AnythingElse.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 @Slide
 struct AnythingElseSlide: View {
+  var transition: AnyTransition = .push(from: .trailing)
+  
   var body: some View {
     Text("他に言いたいことあれば")
       .font(.system(size: 96))

--- a/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
+++ b/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
@@ -10,16 +10,16 @@ public struct iOSDC2025InterviewSlideConfiguration: SlideConfigurationInterface 
   public let size = SlideSize.standard16_9
   public let slideIndexController = SlideIndexController {
     TitleSlide()
-    SelfIntroductionSlide()
-    WhyHostSlide()
-    AfterHostingSlide()
-    MemorableEventSlide()
-    RegionalFlavorSlide()
-    OperationDifficultySlide()
-    NextEventSlide()
-    OtherRegionsSlide()
-    MessageForHostsSlide()
-    AnythingElseSlide()
+    SelfIntroductionSlide(transition: .push(from: .trailing))
+    WhyHostSlide(transition: .push(from: .trailing))
+    AfterHostingSlide(transition: .push(from: .trailing))
+    MemorableEventSlide(transition: .push(from: .trailing))
+    RegionalFlavorSlide(transition: .push(from: .trailing))
+    OperationDifficultySlide(transition: .push(from: .trailing))
+    NextEventSlide(transition: .push(from: .trailing))
+    OtherRegionsSlide(transition: .push(from: .trailing))
+    MessageForHostsSlide(transition: .push(from: .trailing))
+    AnythingElseSlide(transition: .push(from: .trailing))
   }
   public let theme: any SlideTheme = .default
 }

--- a/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
+++ b/Slides/Sources/iOSDC2025Interview/iOSDC2025InterviewSlideConfiguration.swift
@@ -10,16 +10,16 @@ public struct iOSDC2025InterviewSlideConfiguration: SlideConfigurationInterface 
   public let size = SlideSize.standard16_9
   public let slideIndexController = SlideIndexController {
     TitleSlide()
-    SelfIntroductionSlide(transition: .push(from: .trailing))
-    WhyHostSlide(transition: .push(from: .trailing))
-    AfterHostingSlide(transition: .push(from: .trailing))
-    MemorableEventSlide(transition: .push(from: .trailing))
-    RegionalFlavorSlide(transition: .push(from: .trailing))
-    OperationDifficultySlide(transition: .push(from: .trailing))
-    NextEventSlide(transition: .push(from: .trailing))
-    OtherRegionsSlide(transition: .push(from: .trailing))
-    MessageForHostsSlide(transition: .push(from: .trailing))
-    AnythingElseSlide(transition: .push(from: .trailing))
+    SelfIntroductionSlide()
+    WhyHostSlide()
+    AfterHostingSlide()
+    MemorableEventSlide()
+    RegionalFlavorSlide()
+    OperationDifficultySlide()
+    NextEventSlide()
+    OtherRegionsSlide()
+    MessageForHostsSlide()
+    AnythingElseSlide()
   }
   public let theme: any SlideTheme = .default
 }


### PR DESCRIPTION
Add `.push(from: .trailing)` transition to all interview slides and fix a string literal build error.

Initially, transitions were attempted via a configuration file, but the user clarified that `var transition: AnyTransition` needed to be added directly to each slide file. Additionally, a build error in `06_RegionalFlavor.swift` caused by nested double quotes was resolved by changing them to single quotes.