### PR TITLE
Add ExternalStorage slide deck

### DIFF
--- a/Slides/Package.swift
+++ b/Slides/Package.swift
@@ -47,6 +47,10 @@ let package = Package(
       name: "iOSDC2025Interview",
       targets: ["iOSDC2025Interview"]
     ),
+    .library(
+      name: "ExternalStorage",
+      targets: ["ExternalStorage"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/mtj0928/SlideKit.git", from: "0.6.1"),
@@ -70,6 +74,7 @@ let package = Package(
         "SwiftUITransition",
         "visionOSMeetupVol10",
         "iOSDC2025Interview",
+        "ExternalStorage",
       ]
     ),
     .target(
@@ -138,6 +143,14 @@ let package = Package(
       name: "iOSDC2025Interview",
       dependencies: [
         "Common",
+        .product(name: "SlideKit", package: "SlideKit"),
+      ]
+    ),
+    .target(
+      name: "ExternalStorage",
+      dependencies: [
+        "Common",
+        "SelfIntroduce",
         .product(name: "SlideKit", package: "SlideKit"),
       ]
     ),

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -1,6 +1,7 @@
 import AboutSkip
 import Common
 import CreateSpatialPhoto
+import ExternalStorage
 import Potatotips0527
 import SlideKit
 import SwiftUI

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -164,6 +164,18 @@ public struct AppView: View {
             Image(systemName: "chevron.forward")
           }
         }
+
+        Button {
+          store.currentSlideConfiguration = ExternalStorageConfiguration()
+          openWindows()
+        } label: {
+          HStack {
+            Text(ExternalStorageConfiguration.title)
+              .frame(maxWidth: .infinity, alignment: .leading)
+
+            Image(systemName: "chevron.forward")
+          }
+        }
       }
       .navigationTitle(Text("Presentations"))
     }

--- a/Slides/Sources/ExternalStorage/ExternalStorageConfiguration.swift
+++ b/Slides/Sources/ExternalStorage/ExternalStorageConfiguration.swift
@@ -1,0 +1,22 @@
+import Common
+import SelfIntroduce
+import SlideKit
+import SwiftUI
+
+public struct ExternalStorageConfiguration: SlideConfigurationInterface {
+  public init() {}
+
+  public let id: String = "external-storage"
+  public static var title: String = "独自UIで実現する外部ストレージデバイスの読み書き"
+  public let size: CGSize = SlideSize.standard16_9
+  public let slideIndexController = SlideIndexController {
+    TitleSlide()
+    SelfIntroduce()
+    AboutKyuSlide()
+    RealityExternalStorageSlide()
+    ReadExternalStorageSlide()
+    WriteExternalStorageSlide()
+    SummarySlide()
+  }
+  public let theme: any SlideTheme = .default
+}

--- a/Slides/Sources/ExternalStorage/Slides/01_Title.swift
+++ b/Slides/Sources/ExternalStorage/Slides/01_Title.swift
@@ -1,0 +1,16 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct TitleSlide: View {
+  var body: some View {
+    Text("独自UIで実現する外部ストレージデバイスの読み書き")
+      .font(.system(size: 96, weight: .bold))
+  }
+}
+
+#Preview {
+  SlidePreview {
+    TitleSlide()
+  }
+}

--- a/Slides/Sources/ExternalStorage/Slides/02_KyuIntroduce.swift
+++ b/Slides/Sources/ExternalStorage/Slides/02_KyuIntroduce.swift
@@ -1,0 +1,18 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct AboutKyuSlide: View {
+  var body: some View {
+    HeaderSlide("kyu の紹介") {
+      Item("iOSアプリを中心に活動")
+      Item("ブログやコミュニティで情報発信")
+    }
+  }
+}
+
+#Preview {
+  SlidePreview {
+    AboutKyuSlide()
+  }
+}

--- a/Slides/Sources/ExternalStorage/Slides/03_RealityExternalStorage.swift
+++ b/Slides/Sources/ExternalStorage/Slides/03_RealityExternalStorage.swift
@@ -1,0 +1,19 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct RealityExternalStorageSlide: View {
+  var body: some View {
+    HeaderSlide("外部ストレージの現実") {
+      Item("iOSではUIDocumentPickerViewControllerが一般的")
+      Item("接続タイミングを柔軟に扱うのは難しい")
+      Item("他の選択肢を模索する必要がある")
+    }
+  }
+}
+
+#Preview {
+  SlidePreview {
+    RealityExternalStorageSlide()
+  }
+}

--- a/Slides/Sources/ExternalStorage/Slides/04_ReadExternalStorage.swift
+++ b/Slides/Sources/ExternalStorage/Slides/04_ReadExternalStorage.swift
@@ -1,0 +1,19 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct ReadExternalStorageSlide: View {
+  var body: some View {
+    HeaderSlide("外部ストレージを読む") {
+      Item("ImageCaptureCore.frameworkの紹介")
+      Item("AVExternalStorageDeviceDiscoverySessionで接続を検出")
+      Item("取得データを独自UIで表示")
+    }
+  }
+}
+
+#Preview {
+  SlidePreview {
+    ReadExternalStorageSlide()
+  }
+}

--- a/Slides/Sources/ExternalStorage/Slides/05_WriteExternalStorage.swift
+++ b/Slides/Sources/ExternalStorage/Slides/05_WriteExternalStorage.swift
@@ -1,0 +1,18 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct WriteExternalStorageSlide: View {
+  var body: some View {
+    HeaderSlide("外部ストレージに書き込む") {
+      Item("ImageCaptureCore.frameworkを利用して書き込み")
+      Item("進捗やエラーを独自UIでハンドリング")
+    }
+  }
+}
+
+#Preview {
+  SlidePreview {
+    WriteExternalStorageSlide()
+  }
+}

--- a/Slides/Sources/ExternalStorage/Slides/06_Summary.swift
+++ b/Slides/Sources/ExternalStorage/Slides/06_Summary.swift
@@ -1,0 +1,19 @@
+import SlideKit
+import SwiftUI
+
+@Slide
+struct SummarySlide: View {
+  var body: some View {
+    HeaderSlide("まとめ") {
+      Item("UIDocumentPickerViewController以外の方法を紹介")
+      Item("ImageCaptureCore.frameworkで独自UIを構築")
+      Item("外部ストレージとのデータやり取りを自由に")
+    }
+  }
+}
+
+#Preview {
+  SlidePreview {
+    SummarySlide()
+  }
+}


### PR DESCRIPTION
## Summary
- add new slide deck `ExternalStorage` for custom UI with external storage
- wire up `ExternalStorage` to slide list
- expose new target in Package.swift

## Testing
- `swift build` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871ab8be94c8321b8262cb6f7f71c54