### PR TITLE
Send slide configuration id via MultipeerConnectivity

### DIFF
--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -94,6 +94,7 @@ public struct AppView: View {
   @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 
   @State private var showingFullScreenPresentation = false
+  @State private var connector = PresentationMultipeerConnector()
 
   private func openWindows() {
     if supportsMultipleWindows {
@@ -184,6 +185,11 @@ public struct AppView: View {
         #endif
       }
       .navigationTitle(Text("Presentations"))
+    }
+    .onChange(of: store.currentSlideConfiguration) { _, newValue in
+      if let configuration = newValue {
+        connector.sendSlideConfigurationID(configuration.id)
+      }
     }
     #if canImport(UIKit)
       .fullScreenCover(isPresented: $showingFullScreenPresentation) {

--- a/Slides/Sources/App/AppView.swift
+++ b/Slides/Sources/App/AppView.swift
@@ -95,6 +95,7 @@ public struct AppView: View {
 
   @State private var showingFullScreenPresentation = false
   @State private var connector = PresentationMultipeerConnector()
+  @State private var showingBrowser = false
 
   private func openWindows() {
     if supportsMultipleWindows {
@@ -185,6 +186,21 @@ public struct AppView: View {
         #endif
       }
       .navigationTitle(Text("Presentations"))
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Button {
+            showingBrowser = true
+          } label: {
+            HStack {
+              Image(systemName: "person.2")
+              Text("\(connector.connectedPeerCount)")
+            }
+          }
+        }
+      }
+    }
+    .sheet(isPresented: $showingBrowser) {
+      MultipeerBrowserView(connector: connector)
     }
     .onChange(of: store.currentSlideConfiguration) { _, newValue in
       if let configuration = newValue {

--- a/Slides/Sources/App/MultipeerBrowserView.swift
+++ b/Slides/Sources/App/MultipeerBrowserView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import MultipeerConnectivity
+
+#if canImport(UIKit)
+struct MultipeerBrowserView: UIViewControllerRepresentable {
+  let connector: PresentationMultipeerConnector
+  @Environment(\.dismiss) private var dismiss
+
+  func makeUIViewController(context: Context) -> MCBrowserViewController {
+    let controller = connector.makeBrowserViewController()
+    controller.delegate = context.coordinator
+    return controller
+  }
+
+  func updateUIViewController(_ uiViewController: MCBrowserViewController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(dismiss: dismiss)
+  }
+
+  final class Coordinator: NSObject, MCBrowserViewControllerDelegate {
+    let dismiss: DismissAction
+    init(dismiss: DismissAction) {
+      self.dismiss = dismiss
+    }
+
+    func browserViewControllerDidFinish(_ browserViewController: MCBrowserViewController) {
+      dismiss()
+    }
+
+    func browserViewControllerWasCancelled(_ browserViewController: MCBrowserViewController) {
+      dismiss()
+    }
+  }
+}
+#elseif canImport(AppKit)
+struct MultipeerBrowserView: NSViewControllerRepresentable {
+  let connector: PresentationMultipeerConnector
+  @Environment(\.dismiss) private var dismiss
+
+  func makeNSViewController(context: Context) -> MCBrowserViewController {
+    let controller = connector.makeBrowserViewController()
+    controller.delegate = context.coordinator
+    return controller
+  }
+
+  func updateNSViewController(_ nsViewController: MCBrowserViewController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(dismiss: dismiss)
+  }
+
+  final class Coordinator: NSObject, MCBrowserViewControllerDelegate {
+    let dismiss: DismissAction
+    init(dismiss: DismissAction) {
+      self.dismiss = dismiss
+    }
+
+    func browserViewControllerDidFinish(_ browserViewController: MCBrowserViewController) {
+      dismiss()
+    }
+
+    func browserViewControllerWasCancelled(_ browserViewController: MCBrowserViewController) {
+      dismiss()
+    }
+  }
+}
+#endif
+

--- a/Slides/Sources/App/PresentationMultipeerConnector.swift
+++ b/Slides/Sources/App/PresentationMultipeerConnector.swift
@@ -6,14 +6,28 @@ import Observation
 final class PresentationMultipeerConnector: NSObject, MCSessionDelegate, MCNearbyServiceAdvertiserDelegate {
   @ObservationIgnored private let serviceType = "prs-control"
   @ObservationIgnored private let peerID = MCPeerID(displayName: UIDevice.current.name)
-  @ObservationIgnored private lazy var session = MCSession(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
-  @ObservationIgnored private lazy var advertiser = MCNearbyServiceAdvertiser(peer: peerID, discoveryInfo: nil, serviceType: serviceType)
+  @ObservationIgnored private lazy var session = MCSession(
+    peer: peerID,
+    securityIdentity: nil,
+    encryptionPreference: .required
+  )
+  @ObservationIgnored private lazy var advertiser = MCNearbyServiceAdvertiser(
+    peer: peerID,
+    discoveryInfo: nil,
+    serviceType: serviceType
+  )
+
+  var connectedPeerCount = 0
 
   override init() {
     super.init()
     session.delegate = self
     advertiser.delegate = self
     advertiser.startAdvertisingPeer()
+  }
+
+  func makeBrowserViewController() -> MCBrowserViewController {
+    MCBrowserViewController(serviceType: serviceType, session: session)
   }
 
   func sendSlideConfigurationID(_ id: String) {
@@ -28,7 +42,11 @@ final class PresentationMultipeerConnector: NSObject, MCSessionDelegate, MCNearb
 
   // MARK: - MCSessionDelegate
 
-  func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {}
+  func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+    DispatchQueue.main.async {
+      self.connectedPeerCount = session.connectedPeers.count
+    }
+  }
 
   func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {}
 

--- a/Slides/Sources/App/PresentationMultipeerConnector.swift
+++ b/Slides/Sources/App/PresentationMultipeerConnector.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MultipeerConnectivity
+import Observation
+
+@Observable
+final class PresentationMultipeerConnector: NSObject, MCSessionDelegate, MCNearbyServiceAdvertiserDelegate {
+  @ObservationIgnored private let serviceType = "prs-control"
+  @ObservationIgnored private let peerID = MCPeerID(displayName: UIDevice.current.name)
+  @ObservationIgnored private lazy var session = MCSession(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
+  @ObservationIgnored private lazy var advertiser = MCNearbyServiceAdvertiser(peer: peerID, discoveryInfo: nil, serviceType: serviceType)
+
+  override init() {
+    super.init()
+    session.delegate = self
+    advertiser.delegate = self
+    advertiser.startAdvertisingPeer()
+  }
+
+  func sendSlideConfigurationID(_ id: String) {
+    guard !session.connectedPeers.isEmpty else { return }
+    guard let data = id.data(using: .utf8) else { return }
+    do {
+      try session.send(data, toPeers: session.connectedPeers, with: .reliable)
+    } catch {
+      print("Failed to send slide ID: \(error)")
+    }
+  }
+
+  // MARK: - MCSessionDelegate
+
+  func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {}
+
+  func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {}
+
+  func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {}
+
+  func session(
+    _ session: MCSession,
+    didStartReceivingResourceWithName resourceName: String,
+    fromPeer peerID: MCPeerID,
+    with progress: Progress
+  ) {}
+
+  func session(
+    _ session: MCSession,
+    didFinishReceivingResourceWithName resourceName: String,
+    fromPeer peerID: MCPeerID,
+    at localURL: URL?,
+    withError error: Error?
+  ) {}
+
+  // MARK: - MCNearbyServiceAdvertiserDelegate
+
+  func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {}
+
+  func advertiser(
+    _ advertiser: MCNearbyServiceAdvertiser,
+    didReceiveInvitationFromPeer peerID: MCPeerID,
+    withContext context: Data?,
+    invitationHandler: @escaping (Bool, MCSession?) -> Void
+  ) {
+    invitationHandler(true, session)
+  }
+}


### PR DESCRIPTION
## Summary
- send selected slide id over multipeer connectivity when a slide configuration is chosen
- add a MultipeerConnectivity connector for advertising and sending ids
- manage multipeer connector with `@State` and `@Observable` instead of `@StateObject`

## Testing
- `swift build` *(fails: failed to clone repository `https://github.com/mtj0928/SlideKit.git`: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689961300f9883218286e149bf3ac3bb